### PR TITLE
Feature/symphony 4

### DIFF
--- a/C3/AbstractChart.php
+++ b/C3/AbstractChart.php
@@ -49,13 +49,13 @@ abstract class AbstractChart
 
     /**
      * @param string $name
-     * @param mixed  $value
+     * @param array  $args
      *
      * @return $this
      */
-    public function __call($name, $value)
+    public function __call($name, $args)
     {
-        $this->$name = $value;
+        $this->$name = $args[0];
 
         return $this;
     }

--- a/C3/C3js.php
+++ b/C3/C3js.php
@@ -18,8 +18,7 @@ class C3js extends AbstractChart implements ChartInterface
      */
     public function render()
     {
-        $chartJS = "$(function () {";
-        $chartJS .= "\nvar " . (isset($this->bindto) ? $this->bindto : 'chart') . " = new c3.generate({\n";
+        $chartJS = "new c3.generate({";
         $chartJS .= $this->renderBindTo();
         $chartJS .= $this->renderArea();
         $chartJS .= $this->renderSize();
@@ -42,9 +41,19 @@ class C3js extends AbstractChart implements ChartInterface
         $chartJS .= $this->renderDonut();
         $chartJS .= $this->renderGauge();
         $chartJS .= $this->renderTitle();
-        $chartJS .= "});\n";
-        $chartJS .= "});\n";
+        $chartJS .= "})";
 
-        return trim($chartJS);
+        $onload = <<<ONLOAD
+;(function () {
+  var setup = function () { $chartJS }
+  if (document.readyState !== 'loading') {
+    setup()
+  } else {
+    document.addEventListener('DOMContentLoaded', setup)
+  }
+})();
+ONLOAD;
+
+        return trim($onload);
     }
 }

--- a/C3/ChartOption.php
+++ b/C3/ChartOption.php
@@ -41,6 +41,9 @@ class ChartOption
     public function __get($name)
     {
         $option = $this->option;
+        if (!property_exists($this->{$option}, $name)) {
+            $this->{$option}->{$name} = new static($name);
+        }
         $value = $this->{$option}->{$name};
 
         return $value;

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -3,6 +3,6 @@ parameters:
 
 services:
   c3_charts.twig.highcharts_extension:
-    class: %c3_charts.twig_extension.class%
+    class: "%c3_charts.twig_extension.class%"
     tags:
         - { name: twig.extension }

--- a/Resources/doc/installation.md
+++ b/Resources/doc/installation.md
@@ -2,19 +2,6 @@
 
 1. Run `composer require muspelheim/c3charts-bundle`
 
-2. Register the bundle in your `app/AppKernel.php`:
+   This will install this package and automatically update your `config/bundles.php` file, adding `Muspelheim\C3ChartsBundle\MuspelheimC3ChartsBundle` to it.
 
-   ``` php
-    <?php
-    ...
-    public function registerBundles()
-    {
-        $bundles = array(
-            ...
-            new Muspelheim\C3ChartsBundle\MuspelheimC3ChartsBundle(),
-            ...
-        );
-    ...
-   ```
-
-3. That's all!
+2. That's all!

--- a/Resources/doc/usage.md
+++ b/Resources/doc/usage.md
@@ -24,10 +24,10 @@ public function chartAction()
     $chart->title->text('My pretty chart');
     $chart->axis->x->label("Horizontal title");
     $chart->axis->y->label("Vertical title");
-    $chart->data->column($data);
+    $chart->data->columns($data);
 
     return $this->render('::chart.html.twig', array(
-        'chart' => $data
+        'chart' => $chart
     ));
 }
 ```

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,10 @@
 
   "require": {
     "php": ">=5.3",
-    "symfony/symfony": ">=2.7.13 || >=2.8.6 || >3.0.6"
+    "symfony/config": "*",
+    "symfony/dependency-injection": "*",
+    "symfony/http-kernel": "*",
+    "twig/twig": "*"
   },
 
   "autoload": {


### PR DESCRIPTION
This relates to #5, because symphony 4 requires PHP 7.
The code here runs with PHP 7, but does not use any of its new features (like return type hinting).
It should be easy to merge this with code specialized for PHP 7.