### PR TITLE
private twig extension service

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -4,5 +4,6 @@ parameters:
 services:
   c3_charts.twig.highcharts_extension:
     class: "%c3_charts.twig_extension.class%"
+    public: false
     tags:
         - { name: twig.extension }


### PR DESCRIPTION
There is no need to mark twig extension as public for symfony < 3.4 and newer versions mark them as private by default